### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/goreleaser-release.yml
+++ b/.github/workflows/goreleaser-release.yml
@@ -1,5 +1,8 @@
 name: GoReleaser - Release
 
+permissions:
+    contents: write
+
 on:
     push:
         tags: 

--- a/.github/workflows/goreleaser-snapshot.yml
+++ b/.github/workflows/goreleaser-snapshot.yml
@@ -1,5 +1,8 @@
 name: GoReleaser - Snapshot
 
+permissions:
+    contents: read
+
 on:
     pull_request:
         branches: ["master"]


### PR DESCRIPTION
Potential fix for [https://github.com/ninckblokje/csheet/security/code-scanning/2](https://github.com/ninckblokje/csheet/security/code-scanning/2)

To fix the issue, add a `permissions` block to the workflow file. Since the workflow primarily checks out code and runs GoReleaser, it likely only requires `contents: read` permissions. This ensures that the `GITHUB_TOKEN` has the minimal privileges necessary to complete the task.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or within the specific job (`snapshot`) to limit permissions for that job only. In this case, adding it at the root level is recommended for simplicity.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
