### PR TITLE
Updated to Go 1.24 and added RISC-V support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,17 +3,7 @@
 {
 	"name": "Go",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/go:1-1.22-bookworm",
-	"features": {
-		"ghcr.io/marcozac/devcontainer-features/goreleaser:1": {}
-	},
-	"customizations": {
-		"vscode": {
-			"extensions": [
-				"redhat.vscode-yaml"
-			]
-		}
-	},
+	"image": "mcr.microsoft.com/devcontainers/go:1-1.24-bookworm",
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
@@ -22,7 +12,15 @@
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest"
+	"postCreateCommand": "go install github.com/goreleaser/goreleaser/v2@latest && go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"github.vscode-github-actions",
+				"redhat.vscode-yaml"
+			]
+		}
+	}
 
 	// Configure tool-specific properties.
 	// "customizations": {},

--- a/.github/workflows/goreleaser-release.yml
+++ b/.github/workflows/goreleaser-release.yml
@@ -18,7 +18,7 @@ jobs:
             - name: Set up Go
               uses: actions/setup-go@v5
               with:
-                  go-version: '1.22'
+                  go-version: '1.24'
             - name: Run GoReleaser - Release
               uses: goreleaser/goreleaser-action@v5
               with:

--- a/.github/workflows/goreleaser-snapshot.yml
+++ b/.github/workflows/goreleaser-snapshot.yml
@@ -17,7 +17,7 @@ jobs:
             - name: Set up Go
               uses: actions/setup-go@v5
               with:
-                  go-version: '1.22'
+                  go-version: '1.24'
             - name: Run GoReleaser - Snapshot
               uses: goreleaser/goreleaser-action@v5
               with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -23,6 +23,7 @@ builds:
     goarch:
       - amd64
       - arm64
+      - riscv64
 
 archives:
   - formats: [ tar.gz ]

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/ninckblokje/csheet
 
-go 1.22
+go 1.24
 
 require github.com/atotto/clipboard v0.1.4


### PR DESCRIPTION
Updated to Go 1.24 and added RISC-V support, but depends on https://go.dev/doc/install/source#environment. Gereleaser uses that list of valid combo's to determine what to build.